### PR TITLE
Updated git URL to use git:// variant so it can be accessed publicly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 
 	"repository": {
 		"type": "git",
-		"url": "git@github.com:jussi-kalliokoski/node-cubeb"
+		"url": "git://github.com/jussi-kalliokoski/node-cubeb.git"
 	}, 
 
 	"directories": {


### PR DESCRIPTION
The ssh git URL can only be accessed by the owner of that repository or people with commit rights. This change allows anyone to check out the source without modifying the URL.
